### PR TITLE
Re-add ZoomMixins entries to chloride.mixin.json

### DIFF
--- a/src/main/resources/chloride.mixin.json
+++ b/src/main/resources/chloride.mixin.json
@@ -33,6 +33,8 @@
     "QuickLanguageReloadMixin",
     "SkyMixins$HorizonMixin",
     "SkyMixins$DepthFarMixin",
+    "ZoomMixins$CameraMixin",
+    "ZoomMixins$MouseMixin",
     "darkness.DimensionTypeMixin",
     "darkness.FogColorMixin",
     "darkness.LightmapMixin",


### PR DESCRIPTION
﻿Zoom does nothing on the Fabric 26.2 build. The keybind and the Zoom page in
video settings both show up, but holding the key doesn't do anything.

`ZoomMixins$CameraMixin` and `ZoomMixins$MouseMixin` are compiled into the jar
but aren't listed in `chloride.mixin.json`, so they never get applied. Looks
like they were dropped when the branch went from neo to fabric in f5daf73 --
the other fabric-only mixins were re-added there, these two weren't.

This replaces the two entries that were removed. No source changes needed.

Tested on 26.2 fabric with Sodium 0.9.1. Zoom and scroll-to-zoom both work,
and sensitivity resets correctly after unzooming.
